### PR TITLE
Make duplicate namespace nodes not fatal

### DIFF
--- a/core/ns.c
+++ b/core/ns.c
@@ -85,7 +85,8 @@ void lai_install_nsnode(lai_nsnode_t *node) {
             lai_nsnode_t *child = lai_hashtable_chain_get(&parent->children, h, &chain);
             if (!memcmp(child->name, node->name, 4)) {
                 LAI_CLEANUP_FREE_STRING char *fullpath = lai_stringify_node_path(node);
-                lai_panic("trying to install duplicate namespace node %s", fullpath);
+                lai_warn("trying to install duplicate namespace node %s", fullpath);
+                continue;
             }
         }
 


### PR DESCRIPTION
This allows my machine to proceed further into booting while trying out managarm. It then runs into issue #87 so I'm unable to verify that this solves my problem. I checked that it doesn't break in qemu.