### PR TITLE
Add missing include in acpispec/resources.h

### DIFF
--- a/include/acpispec/resources.h
+++ b/include/acpispec/resources.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This file uses `uint*_t` but doesn't include `stdint.h`