### PR TITLE
Add helpers for languages that can't make use of C macros

### DIFF
--- a/include/lai/core.h
+++ b/include/lai/core.h
@@ -61,6 +61,14 @@ struct lai_ns_child_iterator {
 #define LAI_NS_ITERATOR_INITIALIZER {0}
 #define LAI_NS_CHILD_ITERATOR_INITIALIZER(x) {0, x}
 
+static inline void lai_initialize_ns_iterator(struct lai_ns_iterator *iter) {
+    *iter = (struct lai_ns_iterator)LAI_NS_ITERATOR_INITIALIZER;
+}
+
+static inline void lai_initialize_ns_child_iterator(struct lai_ns_child_iterator *iter, lai_nsnode_t *parent) {
+    *iter = (struct lai_ns_child_iterator)LAI_NS_CHILD_ITERATOR_INITIALIZER(parent);
+}
+
 extern volatile uint16_t lai_last_event;
 
 // The remaining of these functions are OS independent!
@@ -137,6 +145,10 @@ lai_api_error_t lai_obj_exec_match_op(int, lai_variable_t*, lai_variable_t*, int
 #else
 #define LAI_VAR_INITIALIZER {0}
 #endif
+
+static inline void lai_var_initialize(lai_variable_t *var) {
+    *var = (lai_variable_t)LAI_VAR_INITIALIZER;
+}
 
 void lai_var_finalize(lai_variable_t *);
 void lai_var_move(lai_variable_t *, lai_variable_t *);

--- a/include/lai/drivers/ec.h
+++ b/include/lai/drivers/ec.h
@@ -19,6 +19,10 @@ struct lai_ec_driver {
 
 #define LAI_EC_DRIVER_INITIALIZER {0}
 
+static inline void lai_initialize_ec_driver(struct lai_ec_driver *ec) {
+    *ec = (struct lai_ec_driver)LAI_EC_DRIVER_INITIALIZER;
+}
+
 void lai_early_init_ec(struct lai_ec_driver *);
 void lai_init_ec(lai_nsnode_t *, struct lai_ec_driver *);
 uint8_t lai_read_ec(uint8_t, struct lai_ec_driver *);

--- a/include/lai/helpers/pci.h
+++ b/include/lai/helpers/pci.h
@@ -33,6 +33,10 @@ struct lai_prt_iterator {
 
 #define LAI_PRT_ITERATOR_INITIALIZER(prt) {0, prt, 0, 0, 0, NULL, 0, 0, 0, 0}
 
+inline void lai_initialize_prt_iterator(struct lai_prt_iterator *iter, lai_variable_t *prt) {
+    *iter = (struct lai_prt_iterator)LAI_PRT_ITERATOR_INITIALIZER(prt);
+}
+
 lai_api_error_t lai_pci_parse_prt(struct lai_prt_iterator *iter);
 
 #ifdef __cplusplus

--- a/include/lai/helpers/resource.h
+++ b/include/lai/helpers/resource.h
@@ -48,6 +48,10 @@ struct lai_resource_view {
     .address_space = 0, .bit_width = 0, .bit_offset = 0,\
     .gsi = 0}
 
+inline static void lai_initialize_resource_view(struct lai_resource_view *view, lai_variable_t *crs) {
+    *view = (struct lai_resource_view)LAI_RESOURCE_VIEW_INITIALIZER(crs);
+}
+
 lai_api_error_t lai_resource_iterate(struct lai_resource_view *);
 
 enum lai_resource_type lai_resource_get_type(struct lai_resource_view *);


### PR DESCRIPTION
This PR adds a few functions that make it easier to use lai from languages other than C/C++.

I have used a different naming scheme for `lai_var_initialize` to make it similar to other `lai_var` functions