### PR TITLE
Update clang-format GitHub Action to version 4.6.1

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v3.4.0
+      uses: jidicula/clang-format-action@v4.6.1
       with:
         clang-format-version: '11'


### PR DESCRIPTION
This fix formatting check of GitHub CI, caused by apt cannot download clang-format package