### PR TITLE
FIX: Move the `mem*` functions to `laihost_mem*` functions.

### DIFF
--- a/core/eval.c
+++ b/core/eval.c
@@ -59,7 +59,7 @@ void lai_eisaid(lai_variable_t *object, const char *id) {
     if (lai_strlen(id) != 7) {
         if (lai_create_string(object, n) != LAI_ERROR_NONE)
             lai_panic("could not allocate memory for string");
-        memcpy(lai_exec_string_access(object), id, n);
+        lai_memcpy(lai_exec_string_access(object), id, n);
         return;
     }
 

--- a/core/eval.c
+++ b/core/eval.c
@@ -59,7 +59,7 @@ void lai_eisaid(lai_variable_t *object, const char *id) {
     if (lai_strlen(id) != 7) {
         if (lai_create_string(object, n) != LAI_ERROR_NONE)
             lai_panic("could not allocate memory for string");
-        lai_memcpy(lai_exec_string_access(object), id, n);
+        laihost_memcpy(lai_exec_string_access(object), id, n);
         return;
     }
 

--- a/core/exec.c
+++ b/core/exec.c
@@ -23,7 +23,7 @@ static lai_api_error_t lai_exec_parse(int parse_mode, lai_state_t *state);
 // Param: lai_nsnode_t *method - identifies the control method
 
 void lai_init_state(lai_state_t *state) {
-    lai_memset(state, 0, sizeof(lai_state_t));
+    laihost_memset(state, 0, sizeof(lai_state_t));
     state->ctxstack_base = state->small_ctxstack;
     state->blkstack_base = state->small_blkstack;
     state->stack_base = state->small_stack;
@@ -425,8 +425,8 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     char *buffer0 = lai_exec_buffer_access(&operand0_convert);
                     char *buffer1 = lai_exec_buffer_access(&operand1_convert);
                     char *result_buffer = lai_exec_buffer_access(&result);
-                    lai_memcpy(result_buffer, buffer0, b0size);
-                    lai_memcpy(result_buffer + b0size, buffer1, b0size);
+                    laihost_memcpy(result_buffer, buffer0, b0size);
+                    laihost_memcpy(result_buffer + b0size, buffer1, b0size);
                     result.type = LAI_BUFFER;
                     break;
                 }
@@ -476,8 +476,8 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     char *string0 = lai_exec_string_access(&operand0_convert);
                     char *string1 = lai_exec_string_access(&operand1_convert);
                     char *result_string = lai_exec_string_access(&result);
-                    lai_memcpy(result_string, string0, s0len);
-                    lai_memcpy(result_string + s0len, string1, s1len);
+                    laihost_memcpy(result_string, string0, s0len);
+                    laihost_memcpy(result_string + s0len, string1, s1len);
                     result_string[s0len + s1len + 1] = '\0';
                     result.type = LAI_STRING;
                 }
@@ -827,7 +827,7 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
 
             if (buf1_size == 0)
                 buf1_size
-                    = 2; // Make it 2 so lai_memcpy will actually copy 0 zero bytes since it is empty
+                    = 2; // Make it 2 so laihost_memcpy will actually copy 0 zero bytes since it is empty
 
             if (buf2_size == 0)
                 buf2_size = 2;
@@ -837,8 +837,8 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
             lai_create_buffer(&result, result_size);
             char *result_buffer = lai_exec_buffer_access(&result);
 
-            lai_memcpy(result_buffer, buf1, buf1_size - 2);
-            lai_memcpy(result_buffer + (buf1_size - 2), buf2, buf2_size - 2);
+            laihost_memcpy(result_buffer, buf1, buf1_size - 2);
+            laihost_memcpy(result_buffer + (buf1_size - 2), buf2, buf2_size - 2);
             result_buffer[(buf1_size - 2) + (buf2_size - 2)] = 0x79; // Small End Tag
 
             // Calculate checksum to put into the End Tag
@@ -1037,7 +1037,7 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     }
                     char *buffer0 = lai_exec_string_access(&object);
                     char *result_string = lai_exec_string_access(&result);
-                    lai_memcpy(result_string, buffer0 + n, sz);
+                    laihost_memcpy(result_string, buffer0 + n, sz);
                     result.type = LAI_STRING;
                     break;
                 }
@@ -1049,7 +1049,7 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     }
                     char *buffer0 = lai_exec_buffer_access(&object);
                     char *result_buffer = lai_exec_buffer_access(&result);
-                    lai_memcpy(result_buffer, buffer0 + n, sz);
+                    laihost_memcpy(result_buffer, buffer0 + n, sz);
                     result.type = LAI_BUFFER;
                     break;
                 }
@@ -1473,7 +1473,7 @@ static lai_api_error_t lai_exec_process(lai_state_t *state) {
                 lai_panic("buffer initializer has negative size");
             if (initial_size > (int)lai_exec_buffer_size(&result))
                 lai_panic("buffer initializer overflows buffer");
-            lai_memcpy(lai_exec_buffer_access(&result), method + block->pc, initial_size);
+            laihost_memcpy(lai_exec_buffer_access(&result), method + block->pc, initial_size);
 
             if (item->buf_want_result) {
                 // Note: there is no need to reserve() as we pop an operand above.
@@ -1597,7 +1597,7 @@ static lai_api_error_t lai_exec_process(lai_state_t *state) {
 
             // TODO: Make sure that this does not leak memory.
             lai_variable_t args[7];
-            lai_memset(args, 0, sizeof(lai_variable_t) * 7);
+            laihost_memset(args, 0, sizeof(lai_variable_t) * 7);
 
             for (int i = 0; i < argc; i++) {
                 struct lai_operand *operand
@@ -1635,7 +1635,7 @@ static lai_api_error_t lai_exec_process(lai_state_t *state) {
                 method_ctxitem->invocation = laihost_malloc(sizeof(struct lai_invocation));
                 if (!method_ctxitem->invocation)
                     lai_panic("could not allocate memory for method invocation");
-                lai_memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
+                laihost_memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
                 lai_list_init(&method_ctxitem->invocation->per_method_list);
 
                 for (int i = 0; i < argc; i++)
@@ -2265,7 +2265,7 @@ static lai_api_error_t lai_exec_parse(int parse_mode, lai_state_t *state) {
                 opstack_res->tag = LAI_OPERAND_OBJECT;
                 if (lai_create_string(&opstack_res->object, n) != LAI_ERROR_NONE)
                     lai_panic("could not allocate memory for string");
-                lai_memcpy(lai_exec_string_access(&opstack_res->object), method + data_pc, n);
+                laihost_memcpy(lai_exec_string_access(&opstack_res->object), method + data_pc, n);
             } else
                 LAI_ENSURE(parse_mode == LAI_EXEC_MODE);
             break;
@@ -3716,7 +3716,7 @@ lai_api_error_t lai_eval_args(lai_variable_t *result, lai_nsnode_t *handle, lai_
                 method_ctxitem->invocation = laihost_malloc(sizeof(struct lai_invocation));
                 if (!method_ctxitem->invocation)
                     lai_panic("could not allocate memory for method invocation");
-                lai_memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
+                laihost_memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
                 lai_list_init(&method_ctxitem->invocation->per_method_list);
 
                 for (int i = 0; i < n; i++)
@@ -3764,7 +3764,7 @@ lai_api_error_t lai_eval_vargs(lai_variable_t *result, lai_nsnode_t *handle, lai
                                va_list vl) {
     int n = 0;
     lai_variable_t args[7];
-    lai_memset(args, 0, sizeof(lai_variable_t) * 7);
+    laihost_memset(args, 0, sizeof(lai_variable_t) * 7);
 
     for (;;) {
         LAI_ENSURE(n < 7 && "ACPI supports at most 7 arguments");

--- a/core/exec.c
+++ b/core/exec.c
@@ -23,7 +23,7 @@ static lai_api_error_t lai_exec_parse(int parse_mode, lai_state_t *state);
 // Param: lai_nsnode_t *method - identifies the control method
 
 void lai_init_state(lai_state_t *state) {
-    memset(state, 0, sizeof(lai_state_t));
+    lai_memset(state, 0, sizeof(lai_state_t));
     state->ctxstack_base = state->small_ctxstack;
     state->blkstack_base = state->small_blkstack;
     state->stack_base = state->small_stack;
@@ -425,8 +425,8 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     char *buffer0 = lai_exec_buffer_access(&operand0_convert);
                     char *buffer1 = lai_exec_buffer_access(&operand1_convert);
                     char *result_buffer = lai_exec_buffer_access(&result);
-                    memcpy(result_buffer, buffer0, b0size);
-                    memcpy(result_buffer + b0size, buffer1, b0size);
+                    lai_memcpy(result_buffer, buffer0, b0size);
+                    lai_memcpy(result_buffer + b0size, buffer1, b0size);
                     result.type = LAI_BUFFER;
                     break;
                 }
@@ -476,8 +476,8 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     char *string0 = lai_exec_string_access(&operand0_convert);
                     char *string1 = lai_exec_string_access(&operand1_convert);
                     char *result_string = lai_exec_string_access(&result);
-                    memcpy(result_string, string0, s0len);
-                    memcpy(result_string + s0len, string1, s1len);
+                    lai_memcpy(result_string, string0, s0len);
+                    lai_memcpy(result_string + s0len, string1, s1len);
                     result_string[s0len + s1len + 1] = '\0';
                     result.type = LAI_STRING;
                 }
@@ -827,7 +827,7 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
 
             if (buf1_size == 0)
                 buf1_size
-                    = 2; // Make it 2 so memcpy will actually copy 0 zero bytes since it is empty
+                    = 2; // Make it 2 so lai_memcpy will actually copy 0 zero bytes since it is empty
 
             if (buf2_size == 0)
                 buf2_size = 2;
@@ -837,8 +837,8 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
             lai_create_buffer(&result, result_size);
             char *result_buffer = lai_exec_buffer_access(&result);
 
-            memcpy(result_buffer, buf1, buf1_size - 2);
-            memcpy(result_buffer + (buf1_size - 2), buf2, buf2_size - 2);
+            lai_memcpy(result_buffer, buf1, buf1_size - 2);
+            lai_memcpy(result_buffer + (buf1_size - 2), buf2, buf2_size - 2);
             result_buffer[(buf1_size - 2) + (buf2_size - 2)] = 0x79; // Small End Tag
 
             // Calculate checksum to put into the End Tag
@@ -1037,7 +1037,7 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     }
                     char *buffer0 = lai_exec_string_access(&object);
                     char *result_string = lai_exec_string_access(&result);
-                    memcpy(result_string, buffer0 + n, sz);
+                    lai_memcpy(result_string, buffer0 + n, sz);
                     result.type = LAI_STRING;
                     break;
                 }
@@ -1049,7 +1049,7 @@ static lai_api_error_t lai_exec_reduce_op(int opcode, lai_state_t *state,
                     }
                     char *buffer0 = lai_exec_buffer_access(&object);
                     char *result_buffer = lai_exec_buffer_access(&result);
-                    memcpy(result_buffer, buffer0 + n, sz);
+                    lai_memcpy(result_buffer, buffer0 + n, sz);
                     result.type = LAI_BUFFER;
                     break;
                 }
@@ -1473,7 +1473,7 @@ static lai_api_error_t lai_exec_process(lai_state_t *state) {
                 lai_panic("buffer initializer has negative size");
             if (initial_size > (int)lai_exec_buffer_size(&result))
                 lai_panic("buffer initializer overflows buffer");
-            memcpy(lai_exec_buffer_access(&result), method + block->pc, initial_size);
+            lai_memcpy(lai_exec_buffer_access(&result), method + block->pc, initial_size);
 
             if (item->buf_want_result) {
                 // Note: there is no need to reserve() as we pop an operand above.
@@ -1597,7 +1597,7 @@ static lai_api_error_t lai_exec_process(lai_state_t *state) {
 
             // TODO: Make sure that this does not leak memory.
             lai_variable_t args[7];
-            memset(args, 0, sizeof(lai_variable_t) * 7);
+            lai_memset(args, 0, sizeof(lai_variable_t) * 7);
 
             for (int i = 0; i < argc; i++) {
                 struct lai_operand *operand
@@ -1635,7 +1635,7 @@ static lai_api_error_t lai_exec_process(lai_state_t *state) {
                 method_ctxitem->invocation = laihost_malloc(sizeof(struct lai_invocation));
                 if (!method_ctxitem->invocation)
                     lai_panic("could not allocate memory for method invocation");
-                memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
+                lai_memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
                 lai_list_init(&method_ctxitem->invocation->per_method_list);
 
                 for (int i = 0; i < argc; i++)
@@ -2265,7 +2265,7 @@ static lai_api_error_t lai_exec_parse(int parse_mode, lai_state_t *state) {
                 opstack_res->tag = LAI_OPERAND_OBJECT;
                 if (lai_create_string(&opstack_res->object, n) != LAI_ERROR_NONE)
                     lai_panic("could not allocate memory for string");
-                memcpy(lai_exec_string_access(&opstack_res->object), method + data_pc, n);
+                lai_memcpy(lai_exec_string_access(&opstack_res->object), method + data_pc, n);
             } else
                 LAI_ENSURE(parse_mode == LAI_EXEC_MODE);
             break;
@@ -3716,7 +3716,7 @@ lai_api_error_t lai_eval_args(lai_variable_t *result, lai_nsnode_t *handle, lai_
                 method_ctxitem->invocation = laihost_malloc(sizeof(struct lai_invocation));
                 if (!method_ctxitem->invocation)
                     lai_panic("could not allocate memory for method invocation");
-                memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
+                lai_memset(method_ctxitem->invocation, 0, sizeof(struct lai_invocation));
                 lai_list_init(&method_ctxitem->invocation->per_method_list);
 
                 for (int i = 0; i < n; i++)
@@ -3764,7 +3764,7 @@ lai_api_error_t lai_eval_vargs(lai_variable_t *result, lai_nsnode_t *handle, lai
                                va_list vl) {
     int n = 0;
     lai_variable_t args[7];
-    memset(args, 0, sizeof(lai_variable_t) * 7);
+    lai_memset(args, 0, sizeof(lai_variable_t) * 7);
 
     for (;;) {
         LAI_ENSURE(n < 7 && "ACPI supports at most 7 arguments");

--- a/core/exec_impl.h
+++ b/core/exec_impl.h
@@ -232,7 +232,7 @@ static inline int lai_exec_reserve_ctxstack(lai_state_t *state) {
             lai_warn("failed to allocate memory for context stack");
             return 1;
         }
-        memcpy(new_stack, state->ctxstack_base,
+        lai_memcpy(new_stack, state->ctxstack_base,
                (state->ctxstack_ptr + 1) * sizeof(struct lai_ctxitem));
         if (state->ctxstack_base != state->small_ctxstack)
             laihost_free(state->ctxstack_base,
@@ -248,7 +248,7 @@ static inline struct lai_ctxitem *lai_exec_push_ctxstack(lai_state_t *state) {
     state->ctxstack_ptr++;
     // Users are expected to call the reserve() function before this one.
     LAI_ENSURE(state->ctxstack_ptr < state->ctxstack_capacity);
-    memset(&state->ctxstack_base[state->ctxstack_ptr], 0, sizeof(struct lai_ctxitem));
+    lai_memset(&state->ctxstack_base[state->ctxstack_ptr], 0, sizeof(struct lai_ctxitem));
     return &state->ctxstack_base[state->ctxstack_ptr];
 }
 
@@ -285,7 +285,7 @@ static inline int lai_exec_reserve_blkstack(lai_state_t *state) {
             lai_warn("failed to allocate memory for block stack");
             return 1;
         }
-        memcpy(new_stack, state->blkstack_base,
+        lai_memcpy(new_stack, state->blkstack_base,
                (state->blkstack_ptr + 1) * sizeof(struct lai_blkitem));
         if (state->blkstack_base != state->small_blkstack)
             laihost_free(state->blkstack_base,
@@ -301,7 +301,7 @@ static inline struct lai_blkitem *lai_exec_push_blkstack(lai_state_t *state) {
     state->blkstack_ptr++;
     // Users are expected to call the reserve() function before this one.
     LAI_ENSURE(state->blkstack_ptr < state->blkstack_capacity);
-    memset(&state->blkstack_base[state->blkstack_ptr], 0, sizeof(struct lai_blkitem));
+    lai_memset(&state->blkstack_base[state->blkstack_ptr], 0, sizeof(struct lai_blkitem));
     return &state->blkstack_base[state->blkstack_ptr];
 }
 
@@ -330,7 +330,7 @@ static inline int lai_exec_reserve_stack(lai_state_t *state) {
             lai_warn("failed to allocate memory for execution stack");
             return 1;
         }
-        memcpy(new_stack, state->stack_base, (state->stack_ptr + 1) * sizeof(lai_stackitem_t));
+        lai_memcpy(new_stack, state->stack_base, (state->stack_ptr + 1) * sizeof(lai_stackitem_t));
         if (state->stack_base != state->small_stack)
             laihost_free(state->stack_base, state->stack_capacity * sizeof(lai_stackitem_t));
         state->stack_base = new_stack;
@@ -384,9 +384,9 @@ static inline int lai_exec_reserve_opstack(lai_state_t *state) {
             lai_warn("failed to allocate memory for operand stack");
             return 1;
         }
-        // TODO: Here, we rely on the fact that moving lai_variable_t via memcpy() is OK.
+        // TODO: Here, we rely on the fact that moving lai_variable_t via lai_memcpy() is OK.
         //       Implement a some sophisticated lai_operand_move()?
-        memcpy(new_stack, state->opstack_base, state->opstack_ptr * sizeof(struct lai_operand));
+        lai_memcpy(new_stack, state->opstack_base, state->opstack_ptr * sizeof(struct lai_operand));
         if (state->opstack_base != state->small_opstack)
             laihost_free(state->opstack_base, state->opstack_capacity * sizeof(struct lai_operand));
         state->opstack_base = new_stack;
@@ -410,7 +410,7 @@ static inline struct lai_operand *lai_exec_push_opstack(lai_state_t *state) {
     // Users are expected to call the reserve() function before this one.
     LAI_ENSURE(state->opstack_ptr < state->opstack_capacity);
     struct lai_operand *object = &state->opstack_base[state->opstack_ptr];
-    memset(object, 0, sizeof(struct lai_operand));
+    lai_memset(object, 0, sizeof(struct lai_operand));
     state->opstack_ptr++;
     return object;
 }

--- a/core/exec_impl.h
+++ b/core/exec_impl.h
@@ -232,7 +232,7 @@ static inline int lai_exec_reserve_ctxstack(lai_state_t *state) {
             lai_warn("failed to allocate memory for context stack");
             return 1;
         }
-        lai_memcpy(new_stack, state->ctxstack_base,
+        laihost_memcpy(new_stack, state->ctxstack_base,
                (state->ctxstack_ptr + 1) * sizeof(struct lai_ctxitem));
         if (state->ctxstack_base != state->small_ctxstack)
             laihost_free(state->ctxstack_base,
@@ -248,7 +248,7 @@ static inline struct lai_ctxitem *lai_exec_push_ctxstack(lai_state_t *state) {
     state->ctxstack_ptr++;
     // Users are expected to call the reserve() function before this one.
     LAI_ENSURE(state->ctxstack_ptr < state->ctxstack_capacity);
-    lai_memset(&state->ctxstack_base[state->ctxstack_ptr], 0, sizeof(struct lai_ctxitem));
+    laihost_memset(&state->ctxstack_base[state->ctxstack_ptr], 0, sizeof(struct lai_ctxitem));
     return &state->ctxstack_base[state->ctxstack_ptr];
 }
 
@@ -285,7 +285,7 @@ static inline int lai_exec_reserve_blkstack(lai_state_t *state) {
             lai_warn("failed to allocate memory for block stack");
             return 1;
         }
-        lai_memcpy(new_stack, state->blkstack_base,
+        laihost_memcpy(new_stack, state->blkstack_base,
                (state->blkstack_ptr + 1) * sizeof(struct lai_blkitem));
         if (state->blkstack_base != state->small_blkstack)
             laihost_free(state->blkstack_base,
@@ -301,7 +301,7 @@ static inline struct lai_blkitem *lai_exec_push_blkstack(lai_state_t *state) {
     state->blkstack_ptr++;
     // Users are expected to call the reserve() function before this one.
     LAI_ENSURE(state->blkstack_ptr < state->blkstack_capacity);
-    lai_memset(&state->blkstack_base[state->blkstack_ptr], 0, sizeof(struct lai_blkitem));
+    laihost_memset(&state->blkstack_base[state->blkstack_ptr], 0, sizeof(struct lai_blkitem));
     return &state->blkstack_base[state->blkstack_ptr];
 }
 
@@ -330,7 +330,7 @@ static inline int lai_exec_reserve_stack(lai_state_t *state) {
             lai_warn("failed to allocate memory for execution stack");
             return 1;
         }
-        lai_memcpy(new_stack, state->stack_base, (state->stack_ptr + 1) * sizeof(lai_stackitem_t));
+        laihost_memcpy(new_stack, state->stack_base, (state->stack_ptr + 1) * sizeof(lai_stackitem_t));
         if (state->stack_base != state->small_stack)
             laihost_free(state->stack_base, state->stack_capacity * sizeof(lai_stackitem_t));
         state->stack_base = new_stack;
@@ -384,9 +384,9 @@ static inline int lai_exec_reserve_opstack(lai_state_t *state) {
             lai_warn("failed to allocate memory for operand stack");
             return 1;
         }
-        // TODO: Here, we rely on the fact that moving lai_variable_t via lai_memcpy() is OK.
+        // TODO: Here, we rely on the fact that moving lai_variable_t via laihost_memcpy() is OK.
         //       Implement a some sophisticated lai_operand_move()?
-        lai_memcpy(new_stack, state->opstack_base, state->opstack_ptr * sizeof(struct lai_operand));
+        laihost_memcpy(new_stack, state->opstack_base, state->opstack_ptr * sizeof(struct lai_operand));
         if (state->opstack_base != state->small_opstack)
             laihost_free(state->opstack_base, state->opstack_capacity * sizeof(struct lai_operand));
         state->opstack_base = new_stack;
@@ -410,7 +410,7 @@ static inline struct lai_operand *lai_exec_push_opstack(lai_state_t *state) {
     // Users are expected to call the reserve() function before this one.
     LAI_ENSURE(state->opstack_ptr < state->opstack_capacity);
     struct lai_operand *object = &state->opstack_base[state->opstack_ptr];
-    lai_memset(object, 0, sizeof(struct lai_operand));
+    laihost_memset(object, 0, sizeof(struct lai_operand));
     state->opstack_ptr++;
     return object;
 }

--- a/core/libc.c
+++ b/core/libc.c
@@ -46,7 +46,7 @@ void *lai_calloc(size_t count, size_t item_size) {
     size_t size = count * item_size;
     void *p = laihost_malloc(size);
     if (p)
-        lai_memset(p, 0, size);
+        laihost_memset(p, 0, size);
     return p;
 }
 

--- a/core/libc.c
+++ b/core/libc.c
@@ -46,7 +46,7 @@ void *lai_calloc(size_t count, size_t item_size) {
     size_t size = count * item_size;
     void *p = laihost_malloc(size);
     if (p)
-        memset(p, 0, size);
+        lai_memset(p, 0, size);
     return p;
 }
 

--- a/core/ns.c
+++ b/core/ns.c
@@ -41,7 +41,7 @@ lai_nsnode_t *lai_create_nsnode(void) {
         return NULL;
     // here we assume that the host does not return zeroed memory,
     // so lai must zero the returned memory itself.
-    memset(node, 0, sizeof(lai_nsnode_t));
+    lai_memset(node, 0, sizeof(lai_nsnode_t));
     return node;
 }
 
@@ -84,7 +84,7 @@ lai_api_error_t lai_install_nsnode(lai_nsnode_t *node) {
         struct lai_hashtable_chain chain = LAI_HASHTABLE_CHAIN_INITIALIZER;
         while (!lai_hashtable_chain_advance(&parent->children, h, &chain)) {
             lai_nsnode_t *child = lai_hashtable_chain_get(&parent->children, h, &chain);
-            if (!memcmp(child->name, node->name, 4)) {
+            if (!lai_memcmp(child->name, node->name, 4)) {
                 LAI_CLEANUP_FREE_STRING char *fullpath = lai_stringify_node_path(node);
                 lai_warn("trying to install duplicate namespace node %s, ignoring", fullpath);
                 return LAI_ERROR_UNEXPECTED_RESULT;
@@ -144,7 +144,7 @@ lai_nsnode_t *lai_ns_get_child(lai_nsnode_t *parent, const char *name) {
     struct lai_hashtable_chain chain = LAI_HASHTABLE_CHAIN_INITIALIZER;
     while (!lai_hashtable_chain_advance(&parent->children, h, &chain)) {
         lai_nsnode_t *child = lai_hashtable_chain_get(&parent->children, h, &chain);
-        if (!memcmp(child->name, name, 4))
+        if (!lai_memcmp(child->name, name, 4))
             return child;
     }
     return NULL;
@@ -534,7 +534,7 @@ static struct lai_aml_segment *lai_load_table(void *ptr, int index) {
     struct lai_aml_segment *amls = laihost_malloc(sizeof(struct lai_aml_segment));
     if (!amls)
         lai_panic("could not allocate memory for struct lai_aml_segment");
-    memset(amls, 0, sizeof(struct lai_aml_segment));
+    lai_memset(amls, 0, sizeof(struct lai_aml_segment));
 
     amls->table = ptr;
     amls->index = index;

--- a/core/ns.c
+++ b/core/ns.c
@@ -41,7 +41,7 @@ lai_nsnode_t *lai_create_nsnode(void) {
         return NULL;
     // here we assume that the host does not return zeroed memory,
     // so lai must zero the returned memory itself.
-    lai_memset(node, 0, sizeof(lai_nsnode_t));
+    laihost_memset(node, 0, sizeof(lai_nsnode_t));
     return node;
 }
 
@@ -84,7 +84,7 @@ lai_api_error_t lai_install_nsnode(lai_nsnode_t *node) {
         struct lai_hashtable_chain chain = LAI_HASHTABLE_CHAIN_INITIALIZER;
         while (!lai_hashtable_chain_advance(&parent->children, h, &chain)) {
             lai_nsnode_t *child = lai_hashtable_chain_get(&parent->children, h, &chain);
-            if (!lai_memcmp(child->name, node->name, 4)) {
+            if (!laihost_memcmp(child->name, node->name, 4)) {
                 LAI_CLEANUP_FREE_STRING char *fullpath = lai_stringify_node_path(node);
                 lai_warn("trying to install duplicate namespace node %s, ignoring", fullpath);
                 return LAI_ERROR_UNEXPECTED_RESULT;
@@ -144,7 +144,7 @@ lai_nsnode_t *lai_ns_get_child(lai_nsnode_t *parent, const char *name) {
     struct lai_hashtable_chain chain = LAI_HASHTABLE_CHAIN_INITIALIZER;
     while (!lai_hashtable_chain_advance(&parent->children, h, &chain)) {
         lai_nsnode_t *child = lai_hashtable_chain_get(&parent->children, h, &chain);
-        if (!lai_memcmp(child->name, name, 4))
+        if (!laihost_memcmp(child->name, name, 4))
             return child;
     }
     return NULL;
@@ -534,7 +534,7 @@ static struct lai_aml_segment *lai_load_table(void *ptr, int index) {
     struct lai_aml_segment *amls = laihost_malloc(sizeof(struct lai_aml_segment));
     if (!amls)
         lai_panic("could not allocate memory for struct lai_aml_segment");
-    lai_memset(amls, 0, sizeof(struct lai_aml_segment));
+    laihost_memset(amls, 0, sizeof(struct lai_aml_segment));
 
     amls->table = ptr;
     amls->index = index;

--- a/core/object.c
+++ b/core/object.c
@@ -21,7 +21,7 @@ lai_api_error_t lai_create_string(lai_variable_t *object, size_t length) {
         laihost_free(object->string_ptr, sizeof(struct lai_string_head));
         return LAI_ERROR_OUT_OF_MEMORY;
     }
-    memset(object->string_ptr->content, 0, length + 1);
+    lai_memset(object->string_ptr->content, 0, length + 1);
     return LAI_ERROR_NONE;
 }
 
@@ -30,7 +30,7 @@ lai_api_error_t lai_create_c_string(lai_variable_t *object, const char *s) {
     lai_api_error_t e = lai_create_string(object, n);
     if (e != LAI_ERROR_NONE)
         return e;
-    memcpy(lai_exec_string_access(object), s, n);
+    lai_memcpy(lai_exec_string_access(object), s, n);
     return LAI_ERROR_NONE;
 }
 
@@ -46,7 +46,7 @@ lai_api_error_t lai_create_buffer(lai_variable_t *object, size_t size) {
         laihost_free(object->buffer_ptr, sizeof(struct lai_buffer_head));
         return LAI_ERROR_OUT_OF_MEMORY;
     }
-    memset(object->buffer_ptr->content, 0, size);
+    lai_memset(object->buffer_ptr->content, 0, size);
     return LAI_ERROR_NONE;
 }
 
@@ -62,7 +62,7 @@ lai_api_error_t lai_create_pkg(lai_variable_t *object, size_t n) {
         laihost_free(object->pkg_ptr, sizeof(struct lai_pkg_head));
         return LAI_ERROR_OUT_OF_MEMORY;
     }
-    memset(object->pkg_ptr->elems, 0, n * sizeof(lai_variable_t));
+    lai_memset(object->pkg_ptr->elems, 0, n * sizeof(lai_variable_t));
     return LAI_ERROR_NONE;
 }
 
@@ -88,8 +88,8 @@ lai_api_error_t lai_obj_resize_buffer(lai_variable_t *object, size_t size) {
         uint8_t *new_content = laihost_malloc(size);
         if (!new_content)
             return LAI_ERROR_OUT_OF_MEMORY;
-        memset(new_content, 0, size);
-        memcpy(new_content, object->buffer_ptr->content, object->buffer_ptr->size);
+        lai_memset(new_content, 0, size);
+        lai_memcpy(new_content, object->buffer_ptr->content, object->buffer_ptr->size);
         laihost_free(object->buffer_ptr->content, object->buffer_ptr->size);
         object->buffer_ptr->content = new_content;
     }
@@ -107,7 +107,7 @@ lai_api_error_t lai_obj_resize_pkg(lai_variable_t *object, size_t n) {
         struct lai_variable_t *new_elems = laihost_malloc(n * sizeof(lai_variable_t));
         if (!new_elems)
             return LAI_ERROR_OUT_OF_MEMORY;
-        memset(new_elems, 0, n * sizeof(lai_variable_t));
+        lai_memset(new_elems, 0, n * sizeof(lai_variable_t));
         for (unsigned int i = 0; i < object->pkg_ptr->size; i++)
             lai_var_move(&new_elems[i], &object->pkg_ptr->elems[i]);
         laihost_free(object->pkg_ptr->elems, object->pkg_ptr->size * sizeof(lai_variable_t));
@@ -219,7 +219,7 @@ lai_api_error_t lai_obj_to_buffer(lai_variable_t *out, lai_variable_t *object) {
         case LAI_TYPE_INTEGER:
             if (lai_create_buffer(out, sizeof(uint64_t)) != LAI_ERROR_NONE)
                 return LAI_ERROR_OUT_OF_MEMORY;
-            memcpy(out->buffer_ptr->content, &object->integer, sizeof(uint64_t));
+            lai_memcpy(out->buffer_ptr->content, &object->integer, sizeof(uint64_t));
             break;
 
         case LAI_TYPE_BUFFER:
@@ -234,7 +234,7 @@ lai_api_error_t lai_obj_to_buffer(lai_variable_t *out, lai_variable_t *object) {
             } else {
                 if (lai_create_buffer(out, len + 1) != LAI_ERROR_NONE)
                     return LAI_ERROR_OUT_OF_MEMORY;
-                memcpy(out->buffer_ptr->content, object->string_ptr->content, len);
+                lai_memcpy(out->buffer_ptr->content, object->string_ptr->content, len);
             }
             break;
         }
@@ -258,8 +258,8 @@ lai_api_error_t lai_mutate_buffer(lai_variable_t *target, lai_variable_t *object
             size_t buffer_size = lai_exec_buffer_size(target);
             if (copy_size > buffer_size)
                 copy_size = buffer_size;
-            memset(lai_exec_buffer_access(target), 0, buffer_size);
-            memcpy(lai_exec_buffer_access(target), lai_exec_buffer_access(object), copy_size);
+            lai_memset(lai_exec_buffer_access(target), 0, buffer_size);
+            lai_memcpy(lai_exec_buffer_access(target), lai_exec_buffer_access(object), copy_size);
             break;
         }
 
@@ -271,8 +271,8 @@ lai_api_error_t lai_mutate_buffer(lai_variable_t *target, lai_variable_t *object
                 copy_size = buffer_size;
             // TODO: bswap() if necessary.
             uint64_t data = object->integer;
-            memset(lai_exec_buffer_access(target), 0, buffer_size);
-            memcpy(lai_exec_buffer_access(target), &data, copy_size);
+            lai_memset(lai_exec_buffer_access(target), 0, buffer_size);
+            lai_memcpy(lai_exec_buffer_access(target), &data, copy_size);
             break;
         }
         case LAI_STRING: {
@@ -280,8 +280,8 @@ lai_api_error_t lai_mutate_buffer(lai_variable_t *target, lai_variable_t *object
             size_t buffer_size = lai_exec_buffer_size(target);
             if (copy_size > buffer_size)
                 copy_size = buffer_size;
-            memset(lai_exec_buffer_access(target), 0, buffer_size);
-            memcpy(lai_exec_buffer_access(target), lai_exec_string_access(object), copy_size);
+            lai_memset(lai_exec_buffer_access(target), 0, buffer_size);
+            lai_memcpy(lai_exec_buffer_access(target), lai_exec_string_access(object), copy_size);
             break;
         }
 
@@ -310,16 +310,16 @@ lai_api_error_t lai_obj_to_string(lai_variable_t *out, lai_variable_t *object, s
                 // Copy until the '\0'
                 lai_create_string(out, buffer_length + 1);
                 char *string = lai_exec_string_access(out);
-                memcpy(string, buffer, buffer_length);
+                lai_memcpy(string, buffer, buffer_length);
             } else {
                 if (size < buffer_length) {
                     lai_create_string(out, size);
                     char *string = lai_exec_string_access(out);
-                    memcpy(string, buffer, size);
+                    lai_memcpy(string, buffer, size);
                 } else {
                     lai_create_string(out, buffer_length);
                     char *string = lai_exec_string_access(out);
-                    memcpy(string, buffer, buffer_length);
+                    lai_memcpy(string, buffer, buffer_length);
                 }
             }
             break;
@@ -666,7 +666,7 @@ lai_api_error_t lai_mutate_integer(lai_variable_t *target, lai_variable_t *objec
             size_t copy_size = lai_exec_buffer_size(object);
             if (copy_size > 8)
                 copy_size = 8;
-            memcpy(&target->integer, lai_exec_buffer_access(object), copy_size);
+            lai_memcpy(&target->integer, lai_exec_buffer_access(object), copy_size);
             // TODO: bswap() if necessary.
             break;
         }
@@ -684,7 +684,7 @@ static void lai_clone_buffer(lai_variable_t *dest, lai_variable_t *source) {
     size_t size = lai_exec_buffer_size(source);
     if (lai_create_buffer(dest, size) != LAI_ERROR_NONE)
         lai_panic("unable to allocate memory for buffer object.");
-    memcpy(lai_exec_buffer_access(dest), lai_exec_buffer_access(source), size);
+    lai_memcpy(lai_exec_buffer_access(dest), lai_exec_buffer_access(source), size);
 }
 
 // lai_clone_string(): Clones a string object
@@ -692,7 +692,7 @@ static void lai_clone_string(lai_variable_t *dest, lai_variable_t *source) {
     size_t n = lai_exec_string_length(source);
     if (lai_create_string(dest, n) != LAI_ERROR_NONE)
         lai_panic("unable to allocate memory for string object.");
-    memcpy(lai_exec_string_access(dest), lai_exec_string_access(source), n);
+    lai_memcpy(lai_exec_string_access(dest), lai_exec_string_access(source), n);
 }
 
 // lai_clone_package(): Clones a package object
@@ -844,7 +844,7 @@ lai_api_error_t lai_obj_exec_match_op(int op, lai_variable_t *var, lai_variable_
             obj_size = lai_exec_string_length(&compare_obj);
         }
 
-        int compare = memcmp(var_data, obj_data, (var_size > obj_size) ? obj_size : var_size);
+        int compare = lai_memcmp(var_data, obj_data, (var_size > obj_size) ? obj_size : var_size);
 
         switch (op) {
             case MATCH_MTR: // MTR: Always True

--- a/core/object.c
+++ b/core/object.c
@@ -21,7 +21,7 @@ lai_api_error_t lai_create_string(lai_variable_t *object, size_t length) {
         laihost_free(object->string_ptr, sizeof(struct lai_string_head));
         return LAI_ERROR_OUT_OF_MEMORY;
     }
-    lai_memset(object->string_ptr->content, 0, length + 1);
+    laihost_memset(object->string_ptr->content, 0, length + 1);
     return LAI_ERROR_NONE;
 }
 
@@ -30,7 +30,7 @@ lai_api_error_t lai_create_c_string(lai_variable_t *object, const char *s) {
     lai_api_error_t e = lai_create_string(object, n);
     if (e != LAI_ERROR_NONE)
         return e;
-    lai_memcpy(lai_exec_string_access(object), s, n);
+    laihost_memcpy(lai_exec_string_access(object), s, n);
     return LAI_ERROR_NONE;
 }
 
@@ -46,7 +46,7 @@ lai_api_error_t lai_create_buffer(lai_variable_t *object, size_t size) {
         laihost_free(object->buffer_ptr, sizeof(struct lai_buffer_head));
         return LAI_ERROR_OUT_OF_MEMORY;
     }
-    lai_memset(object->buffer_ptr->content, 0, size);
+    laihost_memset(object->buffer_ptr->content, 0, size);
     return LAI_ERROR_NONE;
 }
 
@@ -62,7 +62,7 @@ lai_api_error_t lai_create_pkg(lai_variable_t *object, size_t n) {
         laihost_free(object->pkg_ptr, sizeof(struct lai_pkg_head));
         return LAI_ERROR_OUT_OF_MEMORY;
     }
-    lai_memset(object->pkg_ptr->elems, 0, n * sizeof(lai_variable_t));
+    laihost_memset(object->pkg_ptr->elems, 0, n * sizeof(lai_variable_t));
     return LAI_ERROR_NONE;
 }
 
@@ -88,8 +88,8 @@ lai_api_error_t lai_obj_resize_buffer(lai_variable_t *object, size_t size) {
         uint8_t *new_content = laihost_malloc(size);
         if (!new_content)
             return LAI_ERROR_OUT_OF_MEMORY;
-        lai_memset(new_content, 0, size);
-        lai_memcpy(new_content, object->buffer_ptr->content, object->buffer_ptr->size);
+        laihost_memset(new_content, 0, size);
+        laihost_memcpy(new_content, object->buffer_ptr->content, object->buffer_ptr->size);
         laihost_free(object->buffer_ptr->content, object->buffer_ptr->size);
         object->buffer_ptr->content = new_content;
     }
@@ -107,7 +107,7 @@ lai_api_error_t lai_obj_resize_pkg(lai_variable_t *object, size_t n) {
         struct lai_variable_t *new_elems = laihost_malloc(n * sizeof(lai_variable_t));
         if (!new_elems)
             return LAI_ERROR_OUT_OF_MEMORY;
-        lai_memset(new_elems, 0, n * sizeof(lai_variable_t));
+        laihost_memset(new_elems, 0, n * sizeof(lai_variable_t));
         for (unsigned int i = 0; i < object->pkg_ptr->size; i++)
             lai_var_move(&new_elems[i], &object->pkg_ptr->elems[i]);
         laihost_free(object->pkg_ptr->elems, object->pkg_ptr->size * sizeof(lai_variable_t));
@@ -219,7 +219,7 @@ lai_api_error_t lai_obj_to_buffer(lai_variable_t *out, lai_variable_t *object) {
         case LAI_TYPE_INTEGER:
             if (lai_create_buffer(out, sizeof(uint64_t)) != LAI_ERROR_NONE)
                 return LAI_ERROR_OUT_OF_MEMORY;
-            lai_memcpy(out->buffer_ptr->content, &object->integer, sizeof(uint64_t));
+            laihost_memcpy(out->buffer_ptr->content, &object->integer, sizeof(uint64_t));
             break;
 
         case LAI_TYPE_BUFFER:
@@ -234,7 +234,7 @@ lai_api_error_t lai_obj_to_buffer(lai_variable_t *out, lai_variable_t *object) {
             } else {
                 if (lai_create_buffer(out, len + 1) != LAI_ERROR_NONE)
                     return LAI_ERROR_OUT_OF_MEMORY;
-                lai_memcpy(out->buffer_ptr->content, object->string_ptr->content, len);
+                laihost_memcpy(out->buffer_ptr->content, object->string_ptr->content, len);
             }
             break;
         }
@@ -258,8 +258,8 @@ lai_api_error_t lai_mutate_buffer(lai_variable_t *target, lai_variable_t *object
             size_t buffer_size = lai_exec_buffer_size(target);
             if (copy_size > buffer_size)
                 copy_size = buffer_size;
-            lai_memset(lai_exec_buffer_access(target), 0, buffer_size);
-            lai_memcpy(lai_exec_buffer_access(target), lai_exec_buffer_access(object), copy_size);
+            laihost_memset(lai_exec_buffer_access(target), 0, buffer_size);
+            laihost_memcpy(lai_exec_buffer_access(target), lai_exec_buffer_access(object), copy_size);
             break;
         }
 
@@ -271,8 +271,8 @@ lai_api_error_t lai_mutate_buffer(lai_variable_t *target, lai_variable_t *object
                 copy_size = buffer_size;
             // TODO: bswap() if necessary.
             uint64_t data = object->integer;
-            lai_memset(lai_exec_buffer_access(target), 0, buffer_size);
-            lai_memcpy(lai_exec_buffer_access(target), &data, copy_size);
+            laihost_memset(lai_exec_buffer_access(target), 0, buffer_size);
+            laihost_memcpy(lai_exec_buffer_access(target), &data, copy_size);
             break;
         }
         case LAI_STRING: {
@@ -280,8 +280,8 @@ lai_api_error_t lai_mutate_buffer(lai_variable_t *target, lai_variable_t *object
             size_t buffer_size = lai_exec_buffer_size(target);
             if (copy_size > buffer_size)
                 copy_size = buffer_size;
-            lai_memset(lai_exec_buffer_access(target), 0, buffer_size);
-            lai_memcpy(lai_exec_buffer_access(target), lai_exec_string_access(object), copy_size);
+            laihost_memset(lai_exec_buffer_access(target), 0, buffer_size);
+            laihost_memcpy(lai_exec_buffer_access(target), lai_exec_string_access(object), copy_size);
             break;
         }
 
@@ -310,16 +310,16 @@ lai_api_error_t lai_obj_to_string(lai_variable_t *out, lai_variable_t *object, s
                 // Copy until the '\0'
                 lai_create_string(out, buffer_length + 1);
                 char *string = lai_exec_string_access(out);
-                lai_memcpy(string, buffer, buffer_length);
+                laihost_memcpy(string, buffer, buffer_length);
             } else {
                 if (size < buffer_length) {
                     lai_create_string(out, size);
                     char *string = lai_exec_string_access(out);
-                    lai_memcpy(string, buffer, size);
+                    laihost_memcpy(string, buffer, size);
                 } else {
                     lai_create_string(out, buffer_length);
                     char *string = lai_exec_string_access(out);
-                    lai_memcpy(string, buffer, buffer_length);
+                    laihost_memcpy(string, buffer, buffer_length);
                 }
             }
             break;
@@ -666,7 +666,7 @@ lai_api_error_t lai_mutate_integer(lai_variable_t *target, lai_variable_t *objec
             size_t copy_size = lai_exec_buffer_size(object);
             if (copy_size > 8)
                 copy_size = 8;
-            lai_memcpy(&target->integer, lai_exec_buffer_access(object), copy_size);
+            laihost_memcpy(&target->integer, lai_exec_buffer_access(object), copy_size);
             // TODO: bswap() if necessary.
             break;
         }
@@ -684,7 +684,7 @@ static void lai_clone_buffer(lai_variable_t *dest, lai_variable_t *source) {
     size_t size = lai_exec_buffer_size(source);
     if (lai_create_buffer(dest, size) != LAI_ERROR_NONE)
         lai_panic("unable to allocate memory for buffer object.");
-    lai_memcpy(lai_exec_buffer_access(dest), lai_exec_buffer_access(source), size);
+    laihost_memcpy(lai_exec_buffer_access(dest), lai_exec_buffer_access(source), size);
 }
 
 // lai_clone_string(): Clones a string object
@@ -692,7 +692,7 @@ static void lai_clone_string(lai_variable_t *dest, lai_variable_t *source) {
     size_t n = lai_exec_string_length(source);
     if (lai_create_string(dest, n) != LAI_ERROR_NONE)
         lai_panic("unable to allocate memory for string object.");
-    lai_memcpy(lai_exec_string_access(dest), lai_exec_string_access(source), n);
+    laihost_memcpy(lai_exec_string_access(dest), lai_exec_string_access(source), n);
 }
 
 // lai_clone_package(): Clones a package object
@@ -844,7 +844,7 @@ lai_api_error_t lai_obj_exec_match_op(int op, lai_variable_t *var, lai_variable_
             obj_size = lai_exec_string_length(&compare_obj);
         }
 
-        int compare = lai_memcmp(var_data, obj_data, (var_size > obj_size) ? obj_size : var_size);
+        int compare = laihost_memcmp(var_data, obj_data, (var_size > obj_size) ? obj_size : var_size);
 
         switch (op) {
             case MATCH_MTR: // MTR: Always True

--- a/core/opregion.c
+++ b/core/opregion.c
@@ -524,7 +524,7 @@ void lai_read_field(lai_variable_t *destination, lai_nsnode_t *field) {
         lai_read_field_internal(var.buffer_ptr->content, field);
     } else {
         uint8_t buf[bytes];
-        memset(buf, 0, bytes);
+        lai_memset(buf, 0, bytes);
         lai_read_field_internal(buf, field);
 
         uint64_t value = 0;
@@ -546,7 +546,7 @@ void lai_write_field(lai_nsnode_t *field, lai_variable_t *source) {
         lai_write_field_internal((uint8_t *)source->string_ptr->content, field);
     } else if (source->type == LAI_INTEGER) {
         uint8_t buf[8];
-        memset(buf, 0, 8);
+        lai_memset(buf, 0, 8);
 
         for (size_t i = 0; i < 8; i++) {
             buf[i] = (source->integer >> (i * 8)) & 0xFF;

--- a/core/opregion.c
+++ b/core/opregion.c
@@ -524,7 +524,7 @@ void lai_read_field(lai_variable_t *destination, lai_nsnode_t *field) {
         lai_read_field_internal(var.buffer_ptr->content, field);
     } else {
         uint8_t buf[bytes];
-        lai_memset(buf, 0, bytes);
+        laihost_memset(buf, 0, bytes);
         lai_read_field_internal(buf, field);
 
         uint64_t value = 0;
@@ -546,7 +546,7 @@ void lai_write_field(lai_nsnode_t *field, lai_variable_t *source) {
         lai_write_field_internal((uint8_t *)source->string_ptr->content, field);
     } else if (source->type == LAI_INTEGER) {
         uint8_t buf[8];
-        lai_memset(buf, 0, 8);
+        laihost_memset(buf, 0, 8);
 
         for (size_t i = 0; i < 8; i++) {
             buf[i] = (source->integer >> (i * 8)) & 0xFF;

--- a/core/util-hash.h
+++ b/core/util-hash.h
@@ -20,7 +20,7 @@ static void lai_hashtable_grow(struct lai_hashtable *ht, int n, int m) {
     if (!new_elem_ptr_tab || !new_elem_hash_tab || !new_bucket_tab)
         lai_panic("could not allocate memory for children table");
 
-    memset(new_elem_ptr_tab, 0, n * sizeof(void *));
+    lai_memset(new_elem_ptr_tab, 0, n * sizeof(void *));
     for (int i = 0; i < m; i++)
         new_bucket_tab[i] = -1;
 

--- a/core/util-hash.h
+++ b/core/util-hash.h
@@ -20,7 +20,7 @@ static void lai_hashtable_grow(struct lai_hashtable *ht, int n, int m) {
     if (!new_elem_ptr_tab || !new_elem_hash_tab || !new_bucket_tab)
         lai_panic("could not allocate memory for children table");
 
-    lai_memset(new_elem_ptr_tab, 0, n * sizeof(void *));
+    laihost_memset(new_elem_ptr_tab, 0, n * sizeof(void *));
     for (int i = 0; i < m; i++)
         new_bucket_tab[i] = -1;
 

--- a/core/variable.c
+++ b/core/variable.c
@@ -39,7 +39,7 @@ void lai_var_finalize(lai_variable_t *object) {
             break;
     }
 
-    memset(object, 0, sizeof(lai_variable_t));
+    lai_memset(object, 0, sizeof(lai_variable_t));
 }
 
 // Helper function for lai_var_move() and lai_obj_clone().

--- a/core/variable.c
+++ b/core/variable.c
@@ -39,7 +39,7 @@ void lai_var_finalize(lai_variable_t *object) {
             break;
     }
 
-    lai_memset(object, 0, sizeof(lai_variable_t));
+    laihost_memset(object, 0, sizeof(lai_variable_t));
 }
 
 // Helper function for lai_var_move() and lai_obj_clone().

--- a/helpers/pc-bios.c
+++ b/helpers/pc-bios.c
@@ -21,7 +21,7 @@ lai_api_error_t lai_bios_detect_rsdp_within(uintptr_t base, size_t length,
     for (size_t off = 0; off < length; off += 16) {
         acpi_rsdp_t *rsdp = (acpi_rsdp_t *)(window + off);
 
-        if (lai_memcmp(rsdp->signature, "RSD PTR ", 8))
+        if (laihost_memcmp(rsdp->signature, "RSD PTR ", 8))
             continue;
 
         if (lai_bios_calc_checksum(rsdp, sizeof(acpi_rsdp_t)))
@@ -63,7 +63,7 @@ lai_api_error_t lai_bios_detect_rsdp(struct lai_rsdp_info *info) {
     // ACPI specifies that we can find the EBDA through 0x40E.
     uint16_t bda_data;
     void *bda_window = laihost_map(0x40E, sizeof(uint16_t));
-    lai_memcpy(&bda_data, bda_window, sizeof(uint16_t));
+    laihost_memcpy(&bda_data, bda_window, sizeof(uint16_t));
     laihost_unmap(bda_window, sizeof(uint16_t));
 
     uintptr_t ebda_base = ((uintptr_t)bda_data) << 4;

--- a/helpers/pc-bios.c
+++ b/helpers/pc-bios.c
@@ -21,7 +21,7 @@ lai_api_error_t lai_bios_detect_rsdp_within(uintptr_t base, size_t length,
     for (size_t off = 0; off < length; off += 16) {
         acpi_rsdp_t *rsdp = (acpi_rsdp_t *)(window + off);
 
-        if (memcmp(rsdp->signature, "RSD PTR ", 8))
+        if (lai_memcmp(rsdp->signature, "RSD PTR ", 8))
             continue;
 
         if (lai_bios_calc_checksum(rsdp, sizeof(acpi_rsdp_t)))
@@ -63,7 +63,7 @@ lai_api_error_t lai_bios_detect_rsdp(struct lai_rsdp_info *info) {
     // ACPI specifies that we can find the EBDA through 0x40E.
     uint16_t bda_data;
     void *bda_window = laihost_map(0x40E, sizeof(uint16_t));
-    memcpy(&bda_data, bda_window, sizeof(uint16_t));
+    lai_memcpy(&bda_data, bda_window, sizeof(uint16_t));
     laihost_unmap(bda_window, sizeof(uint16_t));
 
     uintptr_t ebda_base = ((uintptr_t)bda_data) << 4;

--- a/include/lai/host.h
+++ b/include/lai/host.h
@@ -43,6 +43,11 @@ void laihost_free(void *, size_t);
 __attribute__((weak)) void laihost_log(int, const char *);
 __attribute__((weak, noreturn)) void laihost_panic(const char *);
 
+__attribute__((weak)) void *laihost_memcpy(void *, const void *, size_t);
+__attribute__((weak)) void *laihost_memmove(void *, const void *, size_t);
+__attribute__((weak)) void *laihost_memset(void *, int, size_t);
+__attribute__((weak)) int laihost_memcmp(const void *, const void *, size_t);
+
 __attribute__((weak)) void *laihost_scan(const char *, size_t);
 __attribute__((weak)) void *laihost_map(size_t, size_t);
 __attribute__((weak)) void laihost_unmap(void *, size_t);

--- a/include/lai/internal-ns.h
+++ b/include/lai/internal-ns.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 __attribute__((always_inline)) inline void lai_namecpy(char *dest, const char *src) {
-    lai_memcpy(dest, src, 4);
+    laihost_memcpy(dest, src, 4);
 }
 
 struct lai_aml_segment {

--- a/include/lai/internal-ns.h
+++ b/include/lai/internal-ns.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 __attribute__((always_inline)) inline void lai_namecpy(char *dest, const char *src) {
-    memcpy(dest, src, 4);
+    lai_memcpy(dest, src, 4);
 }
 
 struct lai_aml_segment {

--- a/include/lai/internal-util.h
+++ b/include/lai/internal-util.h
@@ -14,13 +14,6 @@ extern "C" {
 
 size_t lai_strlen(const char *);
 
-// Even in freestanding environments, GCC requires lai_memcpy(), lai_memmove(), lai_memset()
-// and lai_memcmp() to be present. Thus, we just use them directly.
-void *lai_memcpy(void *, const void *, size_t);
-void *lai_memmove(void *, const void *, size_t);
-void *lai_memset(void *, int, size_t);
-int lai_memcmp(const void *, const void *, size_t);
-
 //---------------------------------------------------------------------------------------
 // Debugging and logging functions.
 //---------------------------------------------------------------------------------------

--- a/include/lai/internal-util.h
+++ b/include/lai/internal-util.h
@@ -14,12 +14,12 @@ extern "C" {
 
 size_t lai_strlen(const char *);
 
-// Even in freestanding environments, GCC requires memcpy(), memmove(), memset()
-// and memcmp() to be present. Thus, we just use them directly.
-void *memcpy(void *, const void *, size_t);
-void *memmove(void *, const void *, size_t);
-void *memset(void *, int, size_t);
-int memcmp(const void *, const void *, size_t);
+// Even in freestanding environments, GCC requires lai_memcpy(), lai_memmove(), lai_memset()
+// and lai_memcmp() to be present. Thus, we just use them directly.
+void *lai_memcpy(void *, const void *, size_t);
+void *lai_memmove(void *, const void *, size_t);
+void *lai_memset(void *, int, size_t);
+int lai_memcmp(const void *, const void *, size_t);
 
 //---------------------------------------------------------------------------------------
 // Debugging and logging functions.


### PR DESCRIPTION
Currently, the functions `memcpy`, `memset`, `memcmp`, and `memmove` (not necessarily in that order) are declared directly in one of LAI's header files. This can cause conflicts if the kernel has already declared these functions. 

To rectify this, this pull request changes those functions into functions required by the host. If the kernel has a standards-compliant implementation of these functions, they can easily integrate these into its LAI bindings by appending the following linker script:
```ld
laihost_memcpy = memcpy;
laihost_memset = memset;
laihost_memcmp = memcmp;
laihost_memmove = memmove;
```

This change will also make the behaviour of the LAI API more consistent, as other C standard functions are defined as host functions in LAI, such as `malloc`, `realloc`, and `free`; which a kernel developer would use a linker script to define the LAI bindings for.